### PR TITLE
Fix hardcoded SYS_ROOT label

### DIFF
--- a/ostree.sh
+++ b/ostree.sh
@@ -203,7 +203,7 @@ function OSTREE_CREATE_LAYOUT {
 function OSTREE_DEPLOY_IMAGE {
     # Update repository and boot entries in GRUB2
     ostree commit --repo="${OSTREE_SYS_ROOT}/ostree/repo" --branch='archlinux/latest' --tree=dir="${OSTREE_SYS_TREE}"
-    ostree admin deploy --sysroot="${OSTREE_SYS_ROOT}" --karg="root=LABEL=SYS_ROOT rw ${OSTREE_SYS_KARG}" --os='archlinux' ${OSTREE_OPT_NOMERGE} --retain archlinux/latest
+    ostree admin deploy --sysroot="${OSTREE_SYS_ROOT}" --karg="root=LABEL=${OSTREE_SYS_ROOT_LABEL} rw ${OSTREE_SYS_KARG}" --os='archlinux' ${OSTREE_OPT_NOMERGE} --retain archlinux/latest
 }
 
 # [OSTREE]: UNDO COMMIT


### PR DESCRIPTION
While trying to use this to deploy an arch linux image on top of an existing fedora silverblue installation, I found a spot where `SYS_ROOT` is hardcoded rather than using the value of `OSTREE_SYS_ROOT_LABEL`. I was able to get it working with this change. Thank you for making this project!